### PR TITLE
Fix and enable basic workflow tests

### DIFF
--- a/src/tests/basic-workflow.test.js
+++ b/src/tests/basic-workflow.test.js
@@ -16,7 +16,7 @@ import {
   moveStep
 } from './test-helpers.js';
 
-describe.skip('Workflow Builder', () => {
+describe('Workflow Builder', () => {
   beforeEach(async () => {
     // Initialize the app with default test workflow for each test
     await initializeWorkflowBuilder(page);


### PR DESCRIPTION
## Summary
- unskip the `basic-workflow.test.js` suite
- update Puppeteer helper utilities to match current data-testid attributes
- implement drag-and-drop movement logic for steps
- wait for initial steps to load when initializing workflow builder

## Testing
- `npm run test:ci -- src/tests/basic-workflow.test.js` *(fails: Step step1 not found)*
